### PR TITLE
Updates the Todoist API Sync endpoint version

### DIFF
--- a/src/Todoist/Client.ts
+++ b/src/Todoist/Client.ts
@@ -1,5 +1,5 @@
 export class Client {
-  private static readonly SYNC_ENDPOINT = 'https://api.todoist.com/sync/v8/sync';
+  private static readonly SYNC_ENDPOINT = 'https://api.todoist.com/sync/v9/sync';
 
   private todoistToken: string;
 


### PR DESCRIPTION
- Updates the API version used from `8` to `9`.
- Please note that this commit will get the integration up and working properly again however the API token should now be passed by Auth header instead of parameter as that is deprecated and will stop working soon.