### PR TITLE
Migrates Todoist API call to Auth header

### DIFF
--- a/src/Todoist/Client.ts
+++ b/src/Todoist/Client.ts
@@ -33,7 +33,7 @@ export class Client {
     const opts: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
       method: 'post',
       contentType: 'application/x-www-form-urlencoded',
-      headers:{Authorization:"Bearer "+this.todoistToken},
+      headers: { Authorization: `Bearer ${this.todoistToken}` }, // eslint-disable-line @typescript-eslint/naming-convention
       muteHttpExceptions: true,
       payload: {
         commands: JSON.stringify(commands)

--- a/src/Todoist/Client.ts
+++ b/src/Todoist/Client.ts
@@ -33,10 +33,10 @@ export class Client {
     const opts: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
       method: 'post',
       contentType: 'application/x-www-form-urlencoded',
+      headers:{Authorization:"Bearer "+this.todoistToken},
       muteHttpExceptions: true,
       payload: {
-        commands: JSON.stringify(commands),
-        token: this.todoistToken,
+        commands: JSON.stringify(commands)
       },
     };
     const response = UrlFetchApp.fetch(Client.SYNC_ENDPOINT, opts);


### PR DESCRIPTION
- Changes token passing to use Authorization Bearer header
- NOTE: Testing recommended to ensure it works as you expect with GAS